### PR TITLE
Update kotlin version to 1.8.20

### DIFF
--- a/.github/workflows/runTest.yml
+++ b/.github/workflows/runTest.yml
@@ -22,19 +22,20 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Runs a single command using the runners shell
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 19
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: corretto
+          java-version: 19
 
       - name: Run Tests with Gradle
         run: ./gradlew test
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: TestResult-${{ matrix.os }}
           path: build/reports/tests

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="19" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.8.20" />
+  </component>
+</project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Kotlin2JvmCompilerArguments">
+    <option name="jvmTarget" value="19" />
+  </component>
+  <component name="KotlinCommonCompilerArguments">
+    <option name="apiVersion" value="1.8" />
+    <option name="languageVersion" value="1.8" />
+  </component>
+  <component name="KotlinCompilerSettings">
+    <option name="additionalArguments" value="-include-runtime -jvm-target 19" />
+  </component>
   <component name="KotlinJpsPluginSettings">
     <option name="version" value="1.8.20" />
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_19" default="true" project-jdk-name="corretto-19" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # myLibForKotlin
 ![RunTest result badge](https://github.com/t-matsumo/myLibForKotlin/workflows/RunTest/badge.svg)
 
-### 参考にしたもの
+# 動かすために必要なもの
+- IntelliJ IDEA 2023.2 (Community Edition)
+- JDK 19 (gradlewを実行するために必要)
+
+# KotlinとJDKのバージョン (updated by https://github.com/t-matsumo/myLibForKotlin/pull/2)
+- Kotlin 1.8.20
+- JDK 19
+
+### ライブラリ部分の参考にしたもの
 - プログラミングコンテストチャレンジブック [第2版]　～問題解決のアルゴリズム活用力とコーディングテクニックを鍛える～
 - https://github.com/atcoder/live_library
 - https://github.com/atcoder/ac-library

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.3.71"
+    kotlin("jvm") version "1.8.20"
 }
 
 group = "org.example"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,9 +12,13 @@ repositories {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
+//    implementation(kotlin("stdlib-jdk8"))
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
+}
+
+kotlin {
+    jvmToolchain(19)
 }
 
 tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+val jvmToolchainVersion: String by project
+
 plugins {
     kotlin("jvm") version "1.8.20"
 }
@@ -22,5 +24,5 @@ tasks.test {
 }
 
 kotlin {
-    jvmToolchain(19)
+    jvmToolchain(jvmToolchainVersion.toInt())
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     kotlin("jvm") version "1.8.20"
 }
@@ -12,26 +10,23 @@ repositories {
 }
 
 dependencies {
-//    implementation(kotlin("stdlib-jdk8"))
-
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
+//    testImplementation(kotlin("test")) // The Kotlin test library いつか移行する
+}
+
+tasks.test {
+    useJUnitPlatform()
+    testLogging {
+        events("passed", "skipped", "failed")
+    }
+}
+
+tasks.named("compileKotlin", org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask::class.java) {
+    compilerOptions {
+        freeCompilerArgs.add("-jvm-target 19")
+    }
 }
 
 kotlin {
     jvmToolchain(19)
-}
-
-tasks {
-    test {
-        useJUnitPlatform()
-        testLogging {
-            events("passed", "skipped", "failed")
-        }
-    }
-
-    withType<KotlinCompile>().configureEach {
-        kotlinOptions {
-            freeCompilerArgs = listOf("-XXLanguage:+InlineClasses")
-        }
-    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,12 +21,6 @@ tasks.test {
     }
 }
 
-tasks.named("compileKotlin", org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask::class.java) {
-    compilerOptions {
-        freeCompilerArgs.add("-jvm-target 19")
-    }
-}
-
 kotlin {
     jvmToolchain(19)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+jvmToolchainVersion=19

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
# なぜバージョンを上げるのか？
AtCoderのジャッジアップデートで言語のバージョンが変わるから

https://img.atcoder.jp/file/language-update/language-list.html

# やったこと
- intelliJ IDEAのバージョンをIntelliJ IDEA 2023.2 (Community Edition)にする
- gradle-wrapperのバージョンを7.6にする(完全にサポートされている最大のバージョン)
　　[対応バージョンの参考](https://kotlinlang.org/docs/gradle-configure-project.html#apply-the-plugin:~:text=%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%82%92%E6%A7%8B%E6%88%90%E3%81%99%E3%82%8B%E3%81%A8%E3%81%8D%E3%81%AF%E3%80%81Kotlin%20Gradle%20%E3%83%97%E3%83%A9%E3%82%B0%E3%82%A4%E3%83%B3%20(KGP)%20%E3%81%A8%E5%88%A9%E7%94%A8%E5%8F%AF%E8%83%BD%E3%81%AA%20Gradle%20%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%B3%E3%81%A8%E3%81%AE%E4%BA%92%E6%8F%9B%E6%80%A7%E3%82%92%E7%A2%BA%E8%AA%8D%E3%81%97%E3%81%A6%E3%81%8F%E3%81%A0%E3%81%95%E3%81%84%E3%80%82%E6%AC%A1%E3%81%AE%E8%A1%A8%E3%81%AB%E3%80%81%E5%AE%8C%E5%85%A8%E3%81%AB%E3%82%B5%E3%83%9D%E3%83%BC%E3%83%88%E3%81%95%E3%82%8C%E3%81%A6%E3%81%84%E3%82%8BGradle%20%E3%81%8A%E3%82%88%E3%81%B3%20Android%20Gradle%20%E3%83%97%E3%83%A9%E3%82%B0%E3%82%A4%E3%83%B3%20(AGP)%20%E3%81%AE%E6%9C%80%E5%B0%8F%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%B3%E3%81%A8%E6%9C%80%E5%A4%A7%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%B3%E3%82%92%E7%A4%BA%E3%81%97%E3%81%BE%E3%81%99%E3%80%82)
- kotlinのバージョンを1.8.20にする a4f4c8864a940407a32de066e3791c122c262654
- Javaのバージョンを19に指定
- Github Actionsの設定を変更